### PR TITLE
[Refactor]関数の引数がString型だったのを&str型に修正

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,8 +61,8 @@ redis-cli ping
 ### データ登録
 
 ```sh
-cargo run add <key> <value>
-cargo run add A100 Alice
+cargo run set <key> <value>
+cargo run set A100 Alice
 ```
 
 ### データ取得

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,13 +10,13 @@ fn connection_handling() -> redis::RedisResult<redis::Connection> {
 }
 
 // Redisにデータを挿入
-fn set_to_redis(mut con: redis::Connection, key: String, value: String) -> redis::RedisResult<()> {
+fn set_to_redis(mut con: redis::Connection, key: &str, value: &str) -> redis::RedisResult<()> {
     let _: () = con.set(&key, &value)?;
     Ok(())
 }
 
 // Redisからデータを取得
-fn get_from_redis(mut con: redis::Connection, key: String) -> redis::RedisResult<String> {
+fn get_from_redis(mut con: redis::Connection, key: &str) -> redis::RedisResult<String> {
    Ok(con.get(&key)?)
 }
 
@@ -56,12 +56,9 @@ fn execute_add_command(con: redis::Connection, params: &[String]) -> Result<(), 
         return Err("usage: cargo run add <key> <value>".to_string());
     }
     
-    let key = params[0].clone();
-    let value = params[1].clone();
-
-    match set_to_redis(con, key.clone(), value.clone()) {
+    match set_to_redis(con, &params[0], &params[1]) {
         Ok(..) => {
-            println!("データ登録完了：キー{}, 値={}", key, value);
+            println!("データ登録完了：キー={}, 値={}", &params[0], &params[1]);
             Ok(())
         }
         Err(e) => {
@@ -76,11 +73,9 @@ fn execute_get_command(con: redis::Connection, params: &[String]) -> Result<(), 
         return Err("usage: cargo run get <key> <value>".to_string());
     }
     
-    let key = params[0].clone();
-    
-    match get_from_redis(con, key.clone()) {
+    match get_from_redis(con, &params[0]) {
         Ok(value) => {
-            println!("データ取得完了：キー{}, 値={}", key, value);
+            println!("データ取得完了：キー={}, 値={}", &params[0], value);
             Ok(())
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,23 +37,23 @@ fn parse_args() -> Result<(String, Vec<String>), String> {
 // 実行方法の表示
 fn show_usage() {
     eprintln!("usage:");
-    eprintln!("  cargo run add <key> <value>");
+    eprintln!("  cargo run set <key> <value>");
     eprintln!("  cargo run get <key>");
 }
 
 // コマンドの実行
 fn execute_command(con: redis::Connection, command: &str, params: &[String]) -> Result<(), String> {
     match command {
-        "add" => execute_add_command(con, params),
+        "set" => execute_set_command(con, params),
         "get" => execute_get_command(con, params),
-        _  => Err("無効なコマンドです。'add' または 'get' を使用してください。".to_string())
+        _  => Err("無効なコマンドです。'set' または 'get' を使用してください。".to_string())
     }
 }
 
-// addコマンドの実行
-fn execute_add_command(con: redis::Connection, params: &[String]) -> Result<(), String> {
+// setコマンドの実行
+fn execute_set_command(con: redis::Connection, params: &[String]) -> Result<(), String> {
     if params.len() != 2 {
-        return Err("usage: cargo run add <key> <value>".to_string());
+        return Err("usage: cargo run set <key> <value>".to_string());
     }
     
     match set_to_redis(con, &params[0], &params[1]) {


### PR DESCRIPTION
1. [refactor: use &str instead of string for function parameters](https://github.com/superneko160/redis_sandbox/commit/1c52c16de43ddb3b10952dabc425dbd1cd6da6e5)
2. [refactor: rename 'add' command to 'set'](https://github.com/superneko160/redis_sandbox/commit/e5f5bb6c903dd07c2a90076a76224af8259977e1)